### PR TITLE
Fix Fatal log messages, Add request attributes and readme info

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ gradlew clean jar
 - Create Request Attributes in Dynatrace.
     - AxwayAppId
     - AxwayAppName
+    - AxwayCorrelationId
     - AxwayOrgName
      
      Go to Settings > Server-side service monitoring > Request Attributes > Define a new request attribute.  Create a Request Attribute for each property with a datasource configured to use an "SDK custom attribute" as in the following screenshot.

--- a/README.md
+++ b/README.md
@@ -28,27 +28,29 @@ gradlew clean jar
 - Copy Aspectj weaver - https://repo1.maven.org/maven2/org/aspectj/aspectjweaver/1.9.6/aspectjweaver-1.9.6.jar to  apigateway/ext/lib
 - Restart API Gateway instances
 - Create a file named jvm.xml under APIGATEWAY_INSTALL_DIR/apigateway/conf/
-- Create Request Attributes in Dynatrace.  Go to Settings > Server-side service monitoring > Request Attributes > Define a new request attribute.  Create a Request Attribute for each property below with a datasource configured to use an "SDK custom attribute" as in the following screenshot.
+    ### API Gateway without API Manager
+    ```xml
+    <ConfigurationFragment>
+        <VMArg name="-javaagent:/home/axway/Axway-7.7.0-Aug2021/apigateway/ext/lib/aspectjweaver-1.9.6.jar"/>
+        <SystemProperty name="apimanager" value="false" />
+    </ConfigurationFragment>
+    ```
+    ### API Gateway and API Manager
+    ```xml
+    <ConfigurationFragment>
+        <VMArg name="-javaagent:/home/axway/Axway-7.7.0-Aug2021/apigateway/ext/lib/aspectjweaver-1.9.6.jar"/>
+    </ConfigurationFragment>
+    ```
+
+- Create Request Attributes in Dynatrace.
     - AxwayAppId
     - AxwayAppName
     - AxwayOrgName
+     
+     Go to Settings > Server-side service monitoring > Request Attributes > Define a new request attribute.  Create a Request Attribute for each property with a datasource configured to use an "SDK custom attribute" as in the following screenshot.
+     
+    ![image](https://user-images.githubusercontent.com/58127265/234663741-32b38f29-371a-4413-9c1a-5b81b6a56af8.png)
 
-![image](https://user-images.githubusercontent.com/58127265/234663741-32b38f29-371a-4413-9c1a-5b81b6a56af8.png)
-
-
-## API Gateway without API Manager
-```xml
-<ConfigurationFragment>
-    <VMArg name="-javaagent:/home/axway/Axway-7.7.0-Aug2021/apigateway/ext/lib/aspectjweaver-1.9.6.jar"/>
-    <SystemProperty name="apimanager" value="false" />
-</ConfigurationFragment>
-```
-## API Gateway and API Manager
-```xml
-<ConfigurationFragment>
-    <VMArg name="-javaagent:/home/axway/Axway-7.7.0-Aug2021/apigateway/ext/lib/aspectjweaver-1.9.6.jar"/>
-</ConfigurationFragment>
-```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ gradlew clean jar
 - Copy Aspectj weaver - https://repo1.maven.org/maven2/org/aspectj/aspectjweaver/1.9.6/aspectjweaver-1.9.6.jar to  apigateway/ext/lib
 - Restart API Gateway instances
 - Create a file named jvm.xml under APIGATEWAY_INSTALL_DIR/apigateway/conf/
+- Create Request Attributes in Dynatrace.  Go to Settings > Server-side service monitoring > Request Attributes > Define a new request attribute.  Create a Request Attribute for each property below with a datasource configured to use an "SDK custom attribute" as in the following screenshot.
+    - AxwayAppId
+    - AxwayAppName
+    - AxwayOrgName
+
+![image](https://user-images.githubusercontent.com/58127265/234663741-32b38f29-371a-4413-9c1a-5b81b6a56af8.png)
+
+
 ## API Gateway without API Manager
 ```xml
 <ConfigurationFragment>

--- a/src/main/java/com/axway/aspects/apim/AxwayAspect.java
+++ b/src/main/java/com/axway/aspects/apim/AxwayAspect.java
@@ -47,7 +47,8 @@ public class AxwayAspect {
             String apiContextRoot = "/";
             String orgName = "defaultFrontend";
             String appName = "defaultFrontend";
-            OneAgentSDKUtils.aroundConsumer(pjp, null, apiName, apiContextRoot, appName, orgName, txn);
+            String appId = "defaultFrontend";
+            OneAgentSDKUtils.aroundConsumer(pjp, null, apiName, apiContextRoot, appName, orgName, appId, txn);
         } else {
             pjp.proceed();
         }
@@ -68,6 +69,7 @@ public class AxwayAspect {
         String apiContextRoot = "/";
         String orgName = "default";
         String appName = "default";
+        String appId = "default";
 
         if (m.get("authentication.application.name") != null) {
             appName = m.get("authentication.application.name").toString();
@@ -82,6 +84,14 @@ public class AxwayAspect {
         } else {
             apiName = uriSplit[1];
         }
-        return OneAgentSDKUtils.aroundConsumer(pjp, m, apiName, apiContextRoot, appName, orgName, null);
+
+        if (m.get("api.path") != null) {
+            apiContextRoot = m.get("api.path").toString();
+        }
+
+        if (m.get("authentication.subject.id") != null) {
+            appId = m.get("authentication.subject.id").toString();
+        }
+        return OneAgentSDKUtils.aroundConsumer(pjp, m, apiName, apiContextRoot, appName, orgName, appId, null);
     }
 }

--- a/src/main/java/com/axway/aspects/apim/TraceLoggingCallback.java
+++ b/src/main/java/com/axway/aspects/apim/TraceLoggingCallback.java
@@ -6,7 +6,7 @@ import com.vordel.trace.Trace;
 public class TraceLoggingCallback implements LoggingCallback {
     @Override
     public void warn(String message) {
-        Trace.fatal("DynatraceModule :" + message);
+        Trace.info("DynatraceModule :" + message);
     }
 
     @Override

--- a/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
+++ b/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
@@ -60,8 +60,6 @@ public class OneAgentSDKUtils {
         OutgoingWebRequestTracer outgoingWebRequestTracer = oneAgentSdk.traceOutgoingWebRequest(getRequestURL(message), getHTTPMethod(message));
         try {
             addoutgoingHeaders(outgoingWebRequestTracer, headers);
-            outgoingWebRequestTracer.start();
-            addRequestAttributes(appName, orgName);
             String outgoingTag = outgoingWebRequestTracer.getDynatraceStringTag();
             Trace.info("Dynatrace :: outgoing x-dynatrace header " + outgoingTag);
             headers.setHeader(OneAgentSDK.DYNATRACE_HTTP_HEADERNAME, outgoingTag);
@@ -71,6 +69,8 @@ public class OneAgentSDKUtils {
             if (message != null) {
                 getAttributes(message);
             }
+            outgoingWebRequestTracer.start();
+            addRequestAttributes(appName, orgName);
             pjp.proceed();
         } catch (Throwable e) {
             Trace.error("Dynatrace :: around producer ", e);

--- a/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
+++ b/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
@@ -66,11 +66,11 @@ public class OneAgentSDKUtils {
             for (Entry<String, HeaderEntry> entry : headers.entrySet()) {
                 outgoingWebRequestTracer.addRequestHeader(entry.getKey(), entry.getValue().toString());
             }
+            outgoingWebRequestTracer.start();
+            addRequestAttributes(appName, orgName);
             if (message != null) {
                 getAttributes(message);
             }
-            outgoingWebRequestTracer.start();
-            addRequestAttributes(appName, orgName);
             pjp.proceed();
         } catch (Throwable e) {
             Trace.error("Dynatrace :: around producer ", e);

--- a/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
+++ b/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
@@ -15,6 +15,7 @@ import com.vordel.trace.Trace;
 import org.aspectj.lang.ProceedingJoinPoint;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -119,7 +120,10 @@ public class OneAgentSDKUtils {
         if (m != null) {
             headers = (HeaderSet) m.get("http.headers");
             if (m.containsKey("leg0")) {
+                Trace.debug("Dynatrace :: Leg0 " + m.get("leg0").getClass());
                 Object[] legZero = (Object[]) m.get("leg0");
+
+                Trace.debug("Dynatrace :: Getting Leg0 data" + Arrays.toString(legZero));
                 if (legZero.length > 1) {
                     Object[] information = (Object[]) legZero[1];
                     if (information.length > 3) {

--- a/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
+++ b/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
@@ -12,6 +12,7 @@ import com.vordel.circuit.net.State;
 import com.vordel.dwe.http.ServerTransaction;
 import com.vordel.mime.HeaderSet;
 import com.vordel.trace.Trace;
+import com.vordel.vary.VariantObject;
 import org.aspectj.lang.ProceedingJoinPoint;
 
 import java.lang.reflect.Field;
@@ -119,18 +120,20 @@ public class OneAgentSDKUtils {
 
         if (m != null) {
             headers = (HeaderSet) m.get("http.headers");
+            /*
             if (m.containsKey("leg0")) {
                 Trace.debug("Dynatrace :: Leg0 " + m.get("leg0").getClass());
-                Object[] legZero = (Object[]) m.get("leg0");
+                VariantObject legZero = (VariantObject) m.get("leg0");
 
-                Trace.debug("Dynatrace :: Getting Leg0 data" + Arrays.toString(legZero));
-                if (legZero.length > 1) {
+                Trace.debug("Dynatrace :: Getting Leg0 data" + legZero);
+                if (legZero) {
                     Object[] information = (Object[]) legZero[1];
                     if (information.length > 3) {
                         correlationId = information[3].toString();
                     }
                 }
             }
+             */
         } else if (txn != null) {
             headers = txn.getHeaders();
         }

--- a/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
+++ b/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
@@ -12,11 +12,9 @@ import com.vordel.circuit.net.State;
 import com.vordel.dwe.http.ServerTransaction;
 import com.vordel.mime.HeaderSet;
 import com.vordel.trace.Trace;
-import com.vordel.vary.VariantObject;
 import org.aspectj.lang.ProceedingJoinPoint;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -120,20 +118,7 @@ public class OneAgentSDKUtils {
 
         if (m != null) {
             headers = (HeaderSet) m.get("http.headers");
-            /*
-            if (m.containsKey("leg0")) {
-                Trace.debug("Dynatrace :: Leg0 " + m.get("leg0").getClass());
-                VariantObject legZero = (VariantObject) m.get("leg0");
-
-                Trace.debug("Dynatrace :: Getting Leg0 data" + legZero);
-                if (legZero) {
-                    Object[] information = (Object[]) legZero[1];
-                    if (information.length > 3) {
-                        correlationId = information[3].toString();
-                    }
-                }
-            }
-             */
+            correlationId = m.getIDBase().toString();
         } else if (txn != null) {
             headers = txn.getHeaders();
         }

--- a/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
+++ b/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
@@ -111,7 +111,7 @@ public class OneAgentSDKUtils {
         Trace.debug("Dynatrace :: Starting around consumer");
 
         Object pjpProceed = null;
-        WebApplicationInfo wsInfo = oneAgentSdk.createWebApplicationInfo("serverNameTest", apiName, apiContextRoot);
+        WebApplicationInfo wsInfo = oneAgentSdk.createWebApplicationInfo("Axway Gateway", apiName, apiContextRoot);
 
         HeaderSet headers = null;
         if (m != null) {
@@ -119,6 +119,13 @@ public class OneAgentSDKUtils {
         } else if (txn != null) {
             headers = txn.getHeaders();
         }
+        if (headers == null) {
+            Trace.debug("Dynatrace :: NO Consumer Headers");
+        }
+        else {
+            Trace.debug("Dynatrace :: Consumer Headers before proceed: " + headers.toString());
+        }
+
         IncomingWebRequestTracer tracer = createIncomingWebRequestTracer(m, txn, wsInfo);
         addIncomingHeaders(tracer, headers);
 
@@ -158,7 +165,6 @@ public class OneAgentSDKUtils {
                 Trace.error("around consumer: if block ", e);
                 tracer.error(e);
             }
-
             Trace.debug("Dynatrace :: aroundConsumer : after processing request");
         } else {
             tracer.start();
@@ -169,6 +175,9 @@ public class OneAgentSDKUtils {
                 Trace.error("Dynatrace :: around consumer in else ", e);
                 tracer.error(e);
             }
+        }
+        if (pjpProceed != null) {
+            Trace.debug(pjpProceed.toString());
         }
         tracer.setStatusCode(getHTTPStatusCode(m));
         tracer.end();
@@ -288,8 +297,14 @@ public class OneAgentSDKUtils {
     public static void addRequestAttributes(String appName, String orgName, String appId) {
         Map<String, String> map;
         map = new HashMap<>();
-        map.put("AxwayAppName", appName);
-        map.put("AxwayOrgName", orgName);
+        if (appName != null) {
+            map.put("AxwayAppName", appName);
+        }
+
+        if (orgName != null) {
+            map.put("AxwayOrgName", orgName);
+        }
+
         if (appId != null) {
             map.put("AxwayAppId", appId);
         }

--- a/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
+++ b/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
@@ -332,7 +332,10 @@ public class OneAgentSDKUtils {
     }
 
     public static void addRequestAttributes(Map<String, String> attributes) {
-        attributes.forEach((key, value) -> oneAgentSdk.addCustomRequestAttribute(key, value));
+        attributes.forEach((key, value) -> {
+            Trace.info("Dynatrace :: " + key + " " + value);
+            oneAgentSdk.addCustomRequestAttribute(key, value);
+        });
     }
 
 }

--- a/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
+++ b/src/main/java/com/axway/oneagent/utils/OneAgentSDKUtils.java
@@ -118,11 +118,13 @@ public class OneAgentSDKUtils {
 
         if (m != null) {
             headers = (HeaderSet) m.get("http.headers");
-            Object[] legZero = (Object[]) m.get("leg0");
-            if (legZero.length > 1) {
-                Object[] information = (Object[]) legZero[1];
-                if (information.length > 3){
-                    correlationId = information[3].toString();
+            if (m.containsKey("leg0")) {
+                Object[] legZero = (Object[]) m.get("leg0");
+                if (legZero.length > 1) {
+                    Object[] information = (Object[]) legZero[1];
+                    if (information.length > 3) {
+                        correlationId = information[3].toString();
+                    }
                 }
             }
         } else if (txn != null) {


### PR DESCRIPTION
The FATAL errors in the axway trace were caused because the headers had to be added before starting the trace.  Most request headers are still not getting into dynatrace and we haven't figured that out.  #10 

Added AxwayAppId and AxwayCorrelationId request attributes to dynatrace and documentation on adding them to dynatrace.

Added additional debug and info logging.  Minor code reorganizing.

Did not update the version.